### PR TITLE
Improve reliability by resolve the nondeterministic of the order of the Map

### DIFF
--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -53,6 +53,7 @@ import scala.Tuple2;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -568,7 +569,7 @@ public class SpatialRDD<T extends Geometry>
                 Geometry spatialObject = iterator.next();
                 Feature jsonFeature;
                 if (spatialObject.getUserData() != null) {
-                    Map<String, Object> fields = new HashMap<String, Object>();
+                    Map<String, Object> fields = new LinkedHashMap<String, Object>();
                     String[] fieldValues = spatialObject.getUserData().toString().split("\t");
                     if (fieldNames != null && fieldValues.length == fieldNames.size()) {
                         for (int i = 0 ; i < fieldValues.length ; i++) {

--- a/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
+++ b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java
@@ -52,7 +52,7 @@ import scala.Tuple2;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -568,7 +568,7 @@ public class SpatialRDD<T extends Geometry>
                 Geometry spatialObject = iterator.next();
                 Feature jsonFeature;
                 if (spatialObject.getUserData() != null) {
-                    Map<String, Object> fields = new HashMap<String, Object>();
+                    Map<String, Object> fields = new LinkedHashMap<String, Object>();
                     String[] fieldValues = spatialObject.getUserData().toString().split("\t");
                     if (fieldNames != null && fieldValues.length == fieldNames.size()) {
                         for (int i = 0 ; i < fieldValues.length ; i++) {


### PR DESCRIPTION
## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/latest-snapshot/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/latest-snapshot/community/develop/)

- No, I haven't read it.

## Is this PR related to a JIRA ticket?

- Yes, the URL of the associated JIRA ticket is https://issues.apache.org/jira/browse/SEDONA-XXX. The PR name follows the format `[SEDONA-XXX] my subject`.

- No, this is a documentation update. The PR name follows the format `[DOCS] my subject`.


## What changes were proposed in this PR?

## Problem :

when the program reading from the newRdd, it assumes the order of the data to read into the Map https://github.com/apache/sedona/blob/a64972027aa4c0fea354898da67a2dd4e6cde46b/spark/common/src/test/java/org/apache/sedona/core/formatMapper/GeoJsonIOTest.java#L106

However, when it write the data, it did not assume the order according to the [Oracle's official document](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html#:~:text=This%20class%20makes%20no%20guarantees%20as%20to%20the%20order%20of%20the%20map)


https://github.com/apache/sedona/blob/a64972027aa4c0fea354898da67a2dd4e6cde46b/spark/common/src/main/java/org/apache/sedona/core/spatialRDD/SpatialRDD.java#L571-L572

So it will cause the ERROR when the environment has been changed

```
org.junit.ComparisonFailure: expected:<0[1]> but was:<0[23]>

	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.sedona.core.formatMapper.GeoJsonIOTest.testReadWriteGeoJson(GeoJsonIOTest.java:115)
```

# Solution

So we can change the Map to use the LinkedHashMap to guarantee the order to solve the problem 


## How was this patch tested?

This error can be reproduced with the [NondexTool](https://github.com/TestingResearchIllinois/NonDex) with the following command (you can try that without modifying the pom, but feel free to use the plugin to protect your project and make it safer 😊 ), and this kind problem is widely documented in [International Dataset of Flaky Tests (IDoFT)](https://github.com/TestingResearchIllinois/idoft)

## Did this PR include necessary documentation updates?

- No, this PR does not affect any functionality public API, only improve the security by making the order deterministic
